### PR TITLE
Harden backend runtime config for Supabase via environment variables.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Sample POST body:
 1. Copy `.env.example` to `.env`
 2. Fill Supabase and OAuth values
 3. Run locally with:
-   - `./run-local.sh`
+   - `./run-local.sh` (auto-loads `.env`)
 
 ---
 

--- a/run-local.sh
+++ b/run-local.sh
@@ -1,2 +1,6 @@
 #!/bin/sh
+set -a
+[ -f .env ] && . ./.env
+set +a
+
 ./gradlew bootRun

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,27 +1,22 @@
-# Database config
-spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driver-class-name=org.h2.Driver
-spring.datasource.username=sa
-spring.datasource.password=
+# Database config (Supabase Postgres via environment)
+spring.datasource.url=${SUPABASE_DB_URL}
+spring.datasource.username=${SUPABASE_DB_USER}
+spring.datasource.password=${SUPABASE_DB_PASSWORD}
 
 # JPA / Hibernate
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.show-sql=true
-
-# H2 Console
-spring.h2.console.enabled=true
-spring.h2.console.path=/h2-console
+spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.hibernate.ddl-auto=${SPRING_JPA_HIBERNATE_DDL_AUTO:update}
+spring.jpa.show-sql=${SPRING_JPA_SHOW_SQL:false}
 
 # Server port
-server.port=8081
+server.port=${PORT:8081}
 
 # Google OAuth2
-spring.security.oauth2.client.registration.google.client-id=YOUR_GOOGLE_CLIENT_ID
-spring.security.oauth2.client.registration.google.client-secret=YOUR_GOOGLE_CLIENT_SECRET
+spring.security.oauth2.client.registration.google.client-id=${SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENT_ID}
+spring.security.oauth2.client.registration.google.client-secret=${SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GOOGLE_CLIENT_SECRET}
 spring.security.oauth2.client.registration.google.scope=openid,profile,email
 
 # GitHub OAuth2
-spring.security.oauth2.client.registration.github.client-id=YOUR_GITHUB_CLIENT_ID
-spring.security.oauth2.client.registration.github.client-secret=YOUR_GITHUB_CLIENT_SECRET
+spring.security.oauth2.client.registration.github.client-id=${SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GITHUB_CLIENT_ID}
+spring.security.oauth2.client.registration.github.client-secret=${SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_GITHUB_CLIENT_SECRET}
 spring.security.oauth2.client.registration.github.scope=read:user,user:email


### PR DESCRIPTION
This removes hardcoded local credentials from application properties and ensures local boot loads .env so database and OAuth secrets stay outside source control.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches local/runtime configuration to rely on environment variables (DB + OAuth) and changes the local run script to source `.env`, which can break startup if env values are missing or misnamed but avoids committing secrets.
> 
> **Overview**
> Hardens runtime configuration by removing H2/local defaults and wiring `application.properties` to read Supabase Postgres and OAuth client secrets strictly from environment variables.
> 
> Updates local development to auto-source `.env` via `run-local.sh` and documents this in `README.md`; also parameterizes `server.port` and makes JPA settings configurable via env-backed defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ad8c3a1c05c86ef12d14880aee659c0a0e8e5c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->